### PR TITLE
Fix export name mismatch in error logger

### DIFF
--- a/utils/errorLogger.js
+++ b/utils/errorLogger.js
@@ -1,7 +1,7 @@
 const db = require('./db');
 const axios = require('axios');
 
-async function logError({ type, message, stack, route, input }) {
+async function logErrorToDB({ type, message, stack, route, input }) {
   try {
     // 1. Save to SQLite
     db.prepare(`
@@ -23,4 +23,4 @@ async function logError({ type, message, stack, route, input }) {
   }
 }
 
-module.exports = { logError };
+module.exports = { logErrorToDB };


### PR DESCRIPTION
## Summary
- rename `logError` to `logErrorToDB`
- update module export

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851511f5888832f806112d89ef753bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal naming for error logging functionality; no changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->