### PR TITLE
Fix puppeteer config flag

### DIFF
--- a/puppeteerConfig.js
+++ b/puppeteerConfig.js
@@ -24,7 +24,7 @@ async function configBrowser() {
     '--disable-infobars',
     '--window-position=0,0',
     '--ignore-certificate-errors',
-    '--ignore-certifcate-errors-spki-list',
+    '--ignore-certificate-errors-spki-list',
     '--disable-dev-shm-usage'
   ];
 


### PR DESCRIPTION
## Summary
- correct typo for certificate errors flag in puppeteerConfig

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685186ab756c832f8a26dcf74737033c