### PR TITLE
Update README API table

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,10 @@ pm2 restart localBrowser
 
 **🧠 Available APIs**
 
-Endpoint	Description
 
-POST /prepare-chat	Open chat session, reuse if exists
-
-POST /chat	Send message, returns latest Gemini reply
-
-POST /close-chat	Gracefully close the active tab
-
-GET /open-login-page	Opens a tab for manual login
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/chat/prepare` | Open chat session, reuse if exists |
+| `POST` | `/chat/message` | Send message and get latest Gemini reply |
+| `POST` | `/chat/close` | Gracefully close the active chat tab |
 


### PR DESCRIPTION
## Summary
- update the Available APIs table in README to list the actual endpoints

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685186ba47b4832f9a84ce444e5fada3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reformatted the API documentation in the README into a markdown table for improved readability.
  - Updated endpoint paths to use a `/chat/` prefix and adjusted their names.
  - Revised endpoint descriptions for clarity.
  - Removed the GET `/open-login-page` endpoint from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->