### PR TITLE
Add jest test for chat route

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -25,6 +25,8 @@
     "puppeteer-extra-plugin-user-preferences": "^2.4.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/tests/chatRoutes.test.js
+++ b/tests/chatRoutes.test.js
@@ -1,0 +1,16 @@
+const request = require('supertest');
+const express = require('express');
+const chatRoutes = require('../routes/chatRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/chat', chatRoutes);
+
+describe('POST /chat/message', () => {
+  test('returns 400 when prompt is empty', async () => {
+    const res = await request(app)
+      .post('/chat/message')
+      .send({ prompt: '' });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest dev dependencies
- add simple test for POST /chat/message
- run tests with `npm test`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685186c1f5f0832f833abdba599911d5