### PR TITLE
Fix docs, listener bug and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ node index.js
 
 API will run at: http://localhost:5000
 
-**For my personal use**  (I  forget too many times) VPS instructions
+**For my personal use**  (I forget too many times) VPS instructions
 
 🔐  Create .env File
 
@@ -108,4 +108,9 @@ pm2 restart localBrowser
 | `POST` | `/chat/prepare` | Open chat session, reuse if exists |
 | `POST` | `/chat/message` | Send message and get latest Gemini reply |
 | `POST` | `/chat/close` | Gracefully close the active chat tab |
+| `POST` | `/browser/execute` | Execute JavaScript in a new browser page |
+| `GET` | `/browser/search` | Search the web using Google |
+| `GET` | `/browser/visit` | Visit the specified URL and return HTML |
+| `GET` | `/browser/scrape` | Scrape a product page using a vendor |
+| `POST` | `/error/report` | Report an error to the server |
 

--- a/helpers/chatManager.js
+++ b/helpers/chatManager.js
@@ -43,12 +43,14 @@ async function sendChat(message) {
   await chatPage.setRequestInterception(true);
   let streamDone = false;
 
-  chatPage.on('requestfinished', req => {
+  const onRequestFinished = req => {
     if (req.url().includes('StreamGenerate')) {
       console.log('[Gemini] StreamGenerate completed');
       streamDone = true;
+      chatPage.off('requestfinished', onRequestFinished);
     }
-  });
+  };
+  chatPage.on('requestfinished', onRequestFinished);
 
   await chatPage.type('rich-textarea', message);
   await chatPage.keyboard.press('Enter');

--- a/tests/chatRoutes.test.js
+++ b/tests/chatRoutes.test.js
@@ -1,5 +1,11 @@
 const request = require('supertest');
 const express = require('express');
+
+jest.mock('../helpers/chatManager', () => ({
+  sendChat: jest.fn()
+}));
+
+const { sendChat } = require('../helpers/chatManager');
 const chatRoutes = require('../routes/chatRoutes');
 
 const app = express();
@@ -12,5 +18,14 @@ describe('POST /chat/message', () => {
       .post('/chat/message')
       .send({ prompt: '' });
     expect(res.status).toBe(400);
+  });
+
+  test('returns reply when prompt is valid', async () => {
+    sendChat.mockResolvedValueOnce('Hello there');
+    const res = await request(app)
+      .post('/chat/message')
+      .send({ prompt: 'Hi' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ reply: 'Hello there' });
   });
 });


### PR DESCRIPTION
## Summary
- fix duplicate space in README
- document browser and error routes in README
- prevent accumulating listeners in `sendChat`
- add positive case test for `/chat/message` and mock chat manager

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685188b86324832f95f12738616ae334