### PR TITLE
Improve server robustness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# .env
+PORT=5000
+API_KEY=
+
+
+
+
+# we wil be using this for whatsapp messages https://whatsender-documentation.amcoders.com/  
+
+WHATSAPP_API=
+WHATSAPP_APPKEY=
+WHATSAPP_AUTHKEY=
+WHATSAPP_TO=
+
+# Optional: Puppeteer headless setting
+HEADLESS=false

--- a/README.md
+++ b/README.md
@@ -27,15 +27,13 @@ npm install
 
 ## 🔐 Environment Setup
 
-Create a `.env` file:
+Copy `.env.example` to `.env` and fill in the values:
 
 ```
-API_KEY=add-your-own-key
-PORT=5000
-GOOGLE_EMAIL=your-email@gmail.com
-GOOGLE_PASSWORD=your-password
+cp .env.example .env
 ```
 
+Edit `.env` to provide your own API key and credentials.
 Only use `.env` for local testing—never commit real credentials.
 
 ## 🧪 Run the Project

--- a/controllers/browserController.js
+++ b/controllers/browserController.js
@@ -7,50 +7,61 @@ const {
 } = require('../helpers/browserHelper'); // moved core logic to helpers
 const { logErrorToDB } = require('../utils/errorLogger');
 // POST /browser/execute
-exports.execute = async (req, res) => {
+exports.execute = async (req, res, next) => {
   try {
     const result = await executeCode(req.body.code || '');
     res.json({ result });
   } catch (err) {
     console.error('[BrowserController] Execute error:', err);
     logErrorToDB({ type: 'EXECUTE_FAILED', message: err.message, stack: err.stack, route: '/browser/execute', input: req.body });
-    res.status(500).json({ error: 'EXECUTE_FAILED', message: err.message });
+    next(err);
   }
 };
 
 // GET /browser/search?q=...
-exports.search = async (req, res) => {
+exports.search = async (req, res, next) => {
+  const query = req.query.q;
+  if (!query || typeof query !== 'string' || query.trim() === '') {
+    return res.status(400).json({ error: 'Invalid parameters' });
+  }
   try {
-    const results = await googleSearch(req.query.q || '');
+    const results = await googleSearch(query);
     res.json({ results });
   } catch (err) {
     console.error('[BrowserController] Search error:', err);
     logErrorToDB({ type: 'SEARCH_FAILED', message: err.message, stack: err.stack, route: '/browser/search', input: req.query });
-    res.status(500).json({ error: 'SEARCH_FAILED', message: err.message });
+    next(err);
   }
 };
 
 // GET /browser/visit?url=...
-exports.visit = async (req, res) => {
+exports.visit = async (req, res, next) => {
+  const url = req.query.url;
+  if (!url || typeof url !== 'string' || !/^https?:\/\//.test(url)) {
+    return res.status(400).json({ error: 'Invalid parameters' });
+  }
   try {
-    const html = await visitUrl(req.query.url || '');
+    const html = await visitUrl(url);
     res.json({ html });
   } catch (err) {
     console.error('[BrowserController] Visit error:', err);
     logErrorToDB({ type: 'VISIT_FAILED', message: err.message, stack: err.stack, route: '/browser/visit', input: req.query });
-    res.status(500).json({ error: 'VISIT_FAILED', message: err.message });
+    next(err);
   }
 };
 
 // GET /browser/scrape?url=...&vendor=...
-exports.scrape = async (req, res) => {
+exports.scrape = async (req, res, next) => {
+  const { url, vendor } = req.query;
+  if (!url || typeof url !== 'string' || !/^https?:\/\//.test(url) || !vendor || typeof vendor !== 'string' || vendor.trim() === '') {
+    return res.status(400).json({ error: 'Invalid parameters' });
+  }
   try {
-    const { url, vendor } = req.query;
     const data = await scrapeProduct(url, vendor);
     res.json(data);
   } catch (err) {
     console.error('[BrowserController] Scrape error:', err);
     logErrorToDB({ type: 'SCRAPE_FAILED', message: err.message, stack: err.stack, route: '/browser/scrape', input: req.query });
-    res.status(500).json({ error: 'SCRAPE_FAILED', message: err.message });
+    next(err);
   }
 };

--- a/controllers/chatController.js
+++ b/controllers/chatController.js
@@ -3,18 +3,18 @@ const { prepareChat, sendChat, closeChat } = require('../helpers/chatManager');
 const { logErrorToDB } = require('../utils/errorLogger');
 
 // Prepare Gemini chat session
-exports.prepare = async (req, res) => {
+exports.prepare = async (req, res, next) => {
   try {
     const result = await prepareChat();
     res.json(result);
   } catch (err) {
     console.error('[ChatController] Prepare error:', err);
-    res.status(500).json({ error: 'CHAT_PREPARE_FAILED', message: err.message });
+    next(err);
   }
 };
 
 // Send a message to Gemini
-exports.message = async (req, res) => {
+exports.message = async (req, res, next) => {
   try {
     const reply = await sendChat(req.body.prompt);
     res.json({ reply });
@@ -27,17 +27,17 @@ exports.message = async (req, res) => {
       route: '/chat/message',
       input: req.body
     });
-    res.status(500).json({ error: 'CHAT_SEND_FAILED', message: err.message });
+    next(err);
   }
 };
 
 // Close Gemini chat tab
-exports.close = async (req, res) => {
+exports.close = async (req, res, next) => {
   try {
     await closeChat();
     res.json({ status: 'chat_closed' });
   } catch (err) {
     console.error('[ChatController] Close error:', err);
-    res.status(500).json({ error: 'CHAT_CLOSE_FAILED', message: err.message });
+    next(err);
   }
 };

--- a/helpers/browserHelper.js
+++ b/helpers/browserHelper.js
@@ -19,9 +19,9 @@ async function googleSearch(query) {
     try {
         await page.goto('https://www.google.com', { waitUntil: 'networkidle2' });
         // Type the query
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await page.waitForTimeout(1000);
         await page.type('textarea[name="q"]', query, { delay: 100 });
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await page.waitForTimeout(1000);
         await page.keyboard.press('Enter');
         await page.waitForNavigation({ waitUntil: 'networkidle2' });
 
@@ -42,7 +42,7 @@ async function googleSearch(query) {
             });
             return items;
         });
-        await new Promise(resolve => setTimeout(resolve, 3000));
+        await page.waitForTimeout(3000);
         return results;
     } finally {
         await page.close();
@@ -83,7 +83,7 @@ async function gotoWithRetry(page, url, options, retries = 1) {
     return await page.goto(url, options);
   } catch (err) {
     if (err.message.includes('Navigation timeout') && retries > 0) {
-      await new Promise(resolve => setTimeout(resolve, 3000)); // wait 3s
+      await page.waitForTimeout(3000); // wait 3s
       return gotoWithRetry(page, url, options, retries - 1);
     }
     throw err;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const app = express();
 const dotenv = require('dotenv');
 dotenv.config();
+const errorHandler = require('./middleware/errorHandler');
 
 // Middleware
 app.use(express.json());
@@ -26,6 +27,9 @@ app.use('/error', require('./routes/errorRoutes'));
 app.get('/', (req, res) => {
   res.json({ status: 'LocalBrowser API is running' });
 });
+
+// Centralized error handler
+app.use(errorHandler);
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,0 +1,6 @@
+function errorHandler(err, req, res, next) {
+  const message = err.message || 'Internal Server Error';
+  res.status(500).json({ error: message });
+}
+
+module.exports = errorHandler;

--- a/tests/browserRoutes.test.js
+++ b/tests/browserRoutes.test.js
@@ -1,0 +1,71 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../helpers/browserHelper', () => ({
+  googleSearch: jest.fn(),
+  visitUrl: jest.fn(),
+  scrapeProduct: jest.fn()
+}));
+
+const { googleSearch, visitUrl, scrapeProduct } = require('../helpers/browserHelper');
+const browserRoutes = require('../routes/browserRoutes');
+const errorHandler = require('../middleware/errorHandler');
+
+const app = express();
+app.use(express.json());
+app.use('/browser', browserRoutes);
+app.use(errorHandler);
+
+describe('Browser routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('GET /browser/search without q returns 400', async () => {
+    const res = await request(app).get('/browser/search');
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /browser/search returns results', async () => {
+    googleSearch.mockResolvedValueOnce(['a']);
+    const res = await request(app).get('/browser/search').query({ q: 'hello' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ results: ['a'] });
+  });
+
+  test('GET /browser/visit without url returns 400', async () => {
+    const res = await request(app).get('/browser/visit');
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /browser/visit with invalid url returns 400', async () => {
+    const res = await request(app).get('/browser/visit').query({ url: 'ftp://x' });
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /browser/visit returns html', async () => {
+    visitUrl.mockResolvedValueOnce('<html></html>');
+    const res = await request(app).get('/browser/visit').query({ url: 'http://x.com' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ html: '<html></html>' });
+  });
+
+  test('GET /browser/scrape with missing params returns 400', async () => {
+    const res = await request(app).get('/browser/scrape').query({ url: 'http://x.com' });
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /browser/scrape returns data', async () => {
+    scrapeProduct.mockResolvedValueOnce({ price: 1 });
+    const res = await request(app).get('/browser/scrape').query({ url: 'http://x.com', vendor: 'v' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ price: 1 });
+  });
+
+  test('Errors are handled by middleware', async () => {
+    googleSearch.mockRejectedValueOnce(new Error('boom'));
+    const res = await request(app).get('/browser/search').query({ q: 'hi' });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'boom' });
+  });
+});

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const logDir = path.resolve(__dirname, '../logs');
 if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir);
+  fs.mkdirSync(logDir, { recursive: true });
 }
 
 const logFile = path.join(logDir, `log-${new Date().toISOString().split('T')[0]}.txt`);
@@ -12,7 +12,9 @@ const logFile = path.join(logDir, `log-${new Date().toISOString().split('T')[0]}
 function logger(message) {
   const timestamp = new Date().toISOString();
   const fullMsg = `[${timestamp}] ${message}\n`;
-  fs.appendFileSync(logFile, fullMsg);
+  fs.appendFile(logFile, fullMsg, err => {
+    if (err) console.error('[logger] Failed to write log:', err.message);
+  });
   console.log(fullMsg.trim());
 }
 


### PR DESCRIPTION
## Summary
- provide `.env.example` and update README instructions
- validate browser route parameters
- use `page.waitForTimeout` for Puppeteer delays
- make logger async and create log directory recursively
- add centralized Express error handler
- add unit tests for browser routes

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518eff3474832f97c2a6c1a0ae8ea9