### PR TITLE
Add database-backed page tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ To use the chat endpoints you must sign in to Gemini manually. Run `POST /chat/p
 | `GET`  | `/browser/search` | Search the web using Google |
 | `GET`  | `/browser/visit`  | Visit the specified URL and return HTML |
 | `GET`  | `/browser/scrape` | Scrape a product page using a vendor |
+| `GET`  | `/pages/list` | List tracked browser pages |
+| `POST` | `/pages/request` | Get or create a page of a given type |
 | `POST` | `/error/report`   | Report an error to the server |
 
 A Postman collection for these endpoints is available in `postman/LocalBrowser.postman_collection.json`. Import it into Postman and set `baseUrl` and `API_KEY` variables to match your environment.

--- a/controllers/pageController.js
+++ b/controllers/pageController.js
@@ -1,0 +1,17 @@
+const { listPages, requestPage } = require('../utils/pageManager');
+
+exports.list = (req, res) => {
+  const pages = listPages();
+  res.json({ pages });
+};
+
+exports.request = async (req, res, next) => {
+  const type = req.query.type;
+  if (!type) return res.status(400).json({ error: 'type query required' });
+  try {
+    const { id } = await requestPage(type);
+    res.json({ pageId: id });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ app.use((req, res, next) => {
 app.use('/chat', require('./routes/chatRoutes'));
 app.use('/browser', require('./routes/browserRoutes'));
 app.use('/error', require('./routes/errorRoutes'));
+app.use('/pages', require('./routes/pageRoutes'));
 
 
 // Default route

--- a/routes/pageRoutes.js
+++ b/routes/pageRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const pageController = require('../controllers/pageController');
+
+router.get('/list', pageController.list);
+router.post('/request', pageController.request);
+
+module.exports = router;

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,7 +1,8 @@
 const Database = require('better-sqlite3');
 const path = require('path');
 
-const dbPath = path.join(__dirname, '../logs/errors.db');
+// Single persistent database for the app
+const dbPath = path.join(__dirname, '../logs/database.db');
 const db = new Database(dbPath);
 
 // Create error_logs table if it doesn't exist
@@ -14,6 +15,17 @@ db.prepare(`
     route TEXT,
     input TEXT,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP
+  )
+`).run();
+
+// Track browser pages
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS active_pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT,
+    status TEXT DEFAULT 'active',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    last_used TEXT DEFAULT CURRENT_TIMESTAMP
   )
 `).run();
 

--- a/utils/pageFactory.js
+++ b/utils/pageFactory.js
@@ -1,7 +1,6 @@
 // utils/pageFactory.js
 const configBrowser = require('../puppeteerConfig');
 let browser = null;
-let chatPage = null;
 
 const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36';
 
@@ -17,18 +16,9 @@ async function getConfiguredPage() {
 }
 
 
-async function getOrCreateChatPage() {
-  if (chatPage && !chatPage.isClosed()) return chatPage;
-
-  browser = await getBrowser();
-  chatPage = await browser.newPage();
-  await chatPage.setUserAgent(userAgent);
-  await chatPage.goto('https://gemini.google.com');
-  return chatPage;
-}
+// creating a new page is handled by the page manager
 
 module.exports = {
   getConfiguredPage,
-  getOrCreateChatPage,
   getBrowser
 };

--- a/utils/pageManager.js
+++ b/utils/pageManager.js
@@ -1,0 +1,77 @@
+const db = require('./db');
+const { getConfiguredPage } = require('./pageFactory');
+
+const pages = new Map(); // id -> Puppeteer Page
+const IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
+function updateStatusIfClosed(id) {
+  const page = pages.get(id);
+  if (!page || page.isClosed()) {
+    db.prepare('UPDATE active_pages SET status = "closed" WHERE id = ?').run(id);
+    pages.delete(id);
+    return true;
+  }
+  return false;
+}
+
+function startCleanupLoop() {
+  setInterval(() => {
+    const threshold = new Date(Date.now() - IDLE_TIMEOUT_MS).toISOString();
+    const stale = db
+      .prepare('SELECT id FROM active_pages WHERE status = "active" AND last_used < ?')
+      .all(threshold);
+    for (const { id } of stale) {
+      const page = pages.get(id);
+      if (page && !page.isClosed()) page.close();
+      db.prepare('UPDATE active_pages SET status = "closed" WHERE id = ?').run(id);
+      pages.delete(id);
+    }
+  }, 60 * 1000);
+}
+
+startCleanupLoop();
+
+async function createPage(type) {
+  const page = await getConfiguredPage();
+  const info = db
+    .prepare('INSERT INTO active_pages (type, status, last_used) VALUES (?, "active", CURRENT_TIMESTAMP)')
+    .run(type);
+  const id = info.lastInsertRowid;
+  pages.set(id, page);
+  page.on('close', () => {
+    db.prepare('UPDATE active_pages SET status = "closed" WHERE id = ?').run(id);
+    pages.delete(id);
+  });
+  return { id, page };
+}
+
+async function requestPage(type) {
+  const row = db
+    .prepare('SELECT id FROM active_pages WHERE type = ? AND status = "active" ORDER BY last_used DESC LIMIT 1')
+    .get(type);
+  if (row) {
+    if (!updateStatusIfClosed(row.id)) {
+      db.prepare('UPDATE active_pages SET last_used = CURRENT_TIMESTAMP WHERE id = ?').run(row.id);
+      return { id: row.id, page: pages.get(row.id) };
+    }
+  }
+  return createPage(type);
+}
+
+function listPages() {
+  return db.prepare('SELECT * FROM active_pages ORDER BY id').all();
+}
+
+function closePage(id) {
+  const page = pages.get(id);
+  if (page && !page.isClosed()) page.close();
+  db.prepare('UPDATE active_pages SET status = "closed" WHERE id = ?').run(id);
+  pages.delete(id);
+}
+
+module.exports = {
+  requestPage,
+  listPages,
+  closePage,
+  updateStatusIfClosed
+};


### PR DESCRIPTION
## Summary
- persist browser pages in a new `active_pages` table
- manage Puppeteer pages with a new page manager and cleanup loop
- update chat manager to request pages dynamically
- expose `/pages` API routes
- document the new endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a481e804832f9a6da5fe0cc5a83f